### PR TITLE
Parallelize redist updates via per-variant anonymous flag + DepotDown…

### DIFF
--- a/.github/variants.json
+++ b/.github/variants.json
@@ -7,7 +7,9 @@
     "dir": "redist/redist-client",
     "nuspec": "redist/redist-client/RocketModFix.Unturned.Redist.Client.nuspec",
     "preview": false,
-    "publicize": false
+    "publicize": false,
+    "anonymous": true,
+    "loginId": 10001
   },
   {
     "variant": "server",
@@ -17,7 +19,9 @@
     "dir": "redist/redist-server",
     "nuspec": "redist/redist-server/RocketModFix.Unturned.Redist.Server.nuspec",
     "preview": false,
-    "publicize": false
+    "publicize": false,
+    "anonymous": false,
+    "loginId": 10002
   },
   {
     "variant": "client-preview",
@@ -27,7 +31,9 @@
     "dir": "redist/redist-client-preview",
     "nuspec": "redist/redist-client-preview/RocketModFix.Unturned.Redist.Client.nuspec",
     "preview": true,
-    "publicize": false
+    "publicize": false,
+    "anonymous": true,
+    "loginId": 10003
   },
   {
     "variant": "server-preview",
@@ -37,7 +43,9 @@
     "dir": "redist/redist-server-preview",
     "nuspec": "redist/redist-server-preview/RocketModFix.Unturned.Redist.Server.nuspec",
     "preview": true,
-    "publicize": false
+    "publicize": false,
+    "anonymous": false,
+    "loginId": 10004
   },
   {
     "variant": "client-preview-old",
@@ -47,7 +55,9 @@
     "dir": "redist/redist-client-preview-old",
     "nuspec": "redist/redist-client-preview-old/RocketModFix.Unturned.Redist.Client.nuspec",
     "preview": false,
-    "publicize": false
+    "publicize": false,
+    "anonymous": true,
+    "loginId": 10005
   },
   {
     "variant": "server-preview-old",
@@ -57,7 +67,9 @@
     "dir": "redist/redist-server-preview-old",
     "nuspec": "redist/redist-server-preview-old/RocketModFix.Unturned.Redist.Server.nuspec",
     "preview": false,
-    "publicize": false
+    "publicize": false,
+    "anonymous": false,
+    "loginId": 10006
   },
   {
     "variant": "client-publicized",
@@ -67,7 +79,9 @@
     "dir": "redist/redist-client-publicized",
     "nuspec": "redist/redist-client-publicized/RocketModFix.Unturned.Redist.Client.nuspec",
     "preview": false,
-    "publicize": true
+    "publicize": true,
+    "anonymous": true,
+    "loginId": 10007
   },
   {
     "variant": "server-publicized",
@@ -77,7 +91,9 @@
     "dir": "redist/redist-server-publicized",
     "nuspec": "redist/redist-server-publicized/RocketModFix.Unturned.Redist.Server.nuspec",
     "preview": false,
-    "publicize": true
+    "publicize": true,
+    "anonymous": false,
+    "loginId": 10008
   },
   {
     "variant": "client-preview-publicized",
@@ -87,7 +103,9 @@
     "dir": "redist/redist-client-preview-publicized",
     "nuspec": "redist/redist-client-preview-publicized/RocketModFix.Unturned.Redist.Client.nuspec",
     "preview": false,
-    "publicize": true
+    "publicize": true,
+    "anonymous": true,
+    "loginId": 10009
   },
   {
     "variant": "server-preview-publicized",
@@ -97,6 +115,8 @@
     "dir": "redist/redist-server-preview-publicized",
     "nuspec": "redist/redist-server-preview-publicized/RocketModFix.Unturned.Redist.Server.nuspec",
     "preview": false,
-    "publicize": true
+    "publicize": true,
+    "anonymous": false,
+    "loginId": 10010
   }
 ]

--- a/.github/workflows/Update.Unturned.Redist.yaml
+++ b/.github/workflows/Update.Unturned.Redist.yaml
@@ -64,6 +64,18 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.load-variants.outputs.variants) }}
+    # Steam allows only one session per account per LoginID. The DepotDownloader
+    # probe handles that with a unique -loginid per variant (see below), so
+    # probes run fully parallel. But steamcmd (the download step) has no LoginID,
+    # so two authenticated variants of the SAME Steam source downloading at once
+    # would still collide. This concurrency group serializes only those: each
+    # anonymous variant gets its own group (fully parallel), while authenticated
+    # variants are grouped by app+branch (same upstream source → serialized;
+    # different sources → still parallel). Anonymous client variants and distinct
+    # server sources all run concurrently.
+    concurrency:
+      group: redist-steam-${{ matrix.anonymous && matrix.variant || format('{0}-{1}', matrix.appId, matrix.branch) }}
+      cancel-in-progress: false
 
     steps:
       - name: Generate branch name
@@ -105,6 +117,8 @@ jobs:
           APP_DEPOT_ID: ${{ matrix.depotId }}
           APP_BRANCH_NAME: ${{ matrix.branch }}
           VARIANT: ${{ matrix.variant }}
+          ANONYMOUS: ${{ matrix.anonymous }}
+          LOGIN_ID: ${{ matrix.loginId }}
         run: |
           set -euo pipefail
           MANIFEST_FILE="redist/redist-manifests/.manifest.redist-${VARIANT}.txt"
@@ -116,6 +130,15 @@ jobs:
             beta_args=(-beta "$APP_BRANCH_NAME")
           fi
 
+          # -loginid makes each variant a distinct Steam session so probes can
+          # run concurrently without "AlreadyLoggedInElsewhere". Authenticated
+          # variants pass credentials; anonymous variants omit them (DepotDownloader
+          # defaults to the anonymous account, which works for the client app).
+          auth_args=(-loginid "$LOGIN_ID")
+          if [ "$ANONYMOUS" != "true" ]; then
+            auth_args+=(-username "$STEAM_USERNAME" -password "$STEAM_PASSWORD")
+          fi
+
           # '|| true': DepotDownloader can exit non-zero even on a successful
           # manifest fetch. We don't trust its exit code — the 19-digit
           # validation below is the real gate (a genuine auth/network failure
@@ -123,9 +146,8 @@ jobs:
           manifest_output=$(depot_downloader/DepotDownloader \
             -app "$APP_ID" \
             -depot "$APP_DEPOT_ID" \
-            -username "$STEAM_USERNAME" \
-            -password "$STEAM_PASSWORD" \
             -manifest-only \
+            "${auth_args[@]}" \
             "${beta_args[@]}" \
             -dir redist/temp_depots || true)
 
@@ -175,19 +197,29 @@ jobs:
           STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
           APP_ID: ${{ matrix.appId }}
           APP_BRANCH_NAME: ${{ matrix.branch }}
+          ANONYMOUS: ${{ matrix.anonymous }}
         run: |
           set -uo pipefail
+          # Anonymous variants (e.g. the client app) log in anonymously; the rest
+          # use the account credentials. steamcmd has no LoginID, so concurrent
+          # authenticated downloads of the same source are serialized by this
+          # job's concurrency group (see the job definition above).
+          if [ "$ANONYMOUS" = "true" ]; then
+            login_args=(+login anonymous)
+          else
+            login_args=(+login "$STEAM_USERNAME" "$STEAM_PASSWORD")
+          fi
+          beta_args=()
+          if [ -n "$APP_BRANCH_NAME" ]; then
+            beta_args=(-beta "$APP_BRANCH_NAME")
+          fi
           # SteamCMD frequently exits non-zero even on a successful download, so
           # its exit code is not a reliable failure signal. We log it but do not
           # fail here — the redist tool below is the real gate (it errors if the
           # game's Managed files aren't present), so a genuinely failed download
           # still turns the run red.
           rc=0
-          if [ -z "$APP_BRANCH_NAME" ]; then
-            steamcmd +force_install_dir "$GITHUB_WORKSPACE" +login "$STEAM_USERNAME" "$STEAM_PASSWORD" +app_update "$APP_ID" -validate +quit || rc=$?
-          else
-            steamcmd +force_install_dir "$GITHUB_WORKSPACE" +login "$STEAM_USERNAME" "$STEAM_PASSWORD" +app_update "$APP_ID" -beta "$APP_BRANCH_NAME" -validate +quit || rc=$?
-          fi
+          steamcmd +force_install_dir "$GITHUB_WORKSPACE" "${login_args[@]}" +app_update "$APP_ID" "${beta_args[@]}" -validate +quit || rc=$?
           if [ "$rc" -ne 0 ]; then
             echo "::warning::steamcmd exited with code $rc (often non-fatal); the redist tool will fail if the game files are actually missing."
           fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,13 +50,24 @@ Every variant is defined **once**, in `.github/variants.json`. All three matrix 
   "dir": "redist/redist-client-preview",
   "nuspec": "redist/redist-client-preview/RocketModFix.Unturned.Redist.Client.nuspec",
   "preview": true,
-  "publicize": false
+  "publicize": false,
+  "anonymous": true,
+  "loginId": 10003
 }
 ```
 
 - `branch`: `""` = Steam default branch, `"preview"` = Steam `preview` beta branch.
 - `preview`: `true` only for the two variants that publish an `-preview<build>` **prerelease** (passes `--preview` to the tool → writes `version.preview.json`).
 - `publicize`: `true` for the publicized variants (passes `-publicize Assembly-CSharp.dll`).
+- `anonymous`: `true` = download with Steam anonymous login (no credentials); `false` = use the account in `STEAM_USERNAME`/`STEAM_PASSWORD`. The **client** app downloads anonymously; the **server** build requires the account.
+- `loginId`: a unique 32-bit integer per variant, passed to DepotDownloader as `-loginid` so the manifest probes can run concurrently on one account (see below).
+
+### Steam login concurrency
+
+Steam allows only one session per account per *LoginID*, so concurrent logins with the same account would otherwise fail with `AlreadyLoggedInElsewhere`. Two mechanisms keep the matrix parallel:
+
+1. **Manifest probe (DepotDownloader)** — each variant uses its unique `loginId`, so all probes run in parallel; anonymous variants don't even use the account.
+2. **Download (`steamcmd`)** — `steamcmd` can't take a LoginID, so the `update_redist` job sets a `concurrency` group: anonymous variants get a unique group (fully parallel), while authenticated variants are grouped by `app+branch` (same Steam source → serialized; different sources → still parallel). In practice the client variants run fully parallel and the server variants serialize only within their shared source.
 
 ## The 4 sources → 10 directories → 6 packages
 
@@ -97,7 +108,7 @@ This lets the redist faithfully follow upstream rollbacks instead of getting stu
 ## How to add a new variant
 
 1. Create the redist directory and its `.nuspec` under `redist/` (matching the existing layout).
-2. Add **one object** to `.github/variants.json` with all fields (`variant`, `appId`, `depotId`, `branch`, `dir`, `nuspec`, `preview`, `publicize`).
+2. Add **one object** to `.github/variants.json` with all fields (`variant`, `appId`, `depotId`, `branch`, `dir`, `nuspec`, `preview`, `publicize`, `anonymous`, `loginId`). Give it a `loginId` not used by any other variant.
 
 That's it — `Update`, `Matrix`, and `Verify` all derive their matrices from that file. (The `workflow_dispatch` `variant` input is a free-form string validated against `variants.json`, so no dropdown to update.)
 


### PR DESCRIPTION
…loader -loginid

Replaces the blunt max-parallel:1 serialization. variants.json gains two fields per variant: 'anonymous' (client app downloads anonymously; server build needs the account) and 'loginId' (unique 32-bit Steam LoginID). Manifest probes pass a unique -loginid so all run concurrently on one account; anonymous variants omit credentials. For the steamcmd download (no LoginID), the update_redist job uses a concurrency group so only authenticated variants of the same app+branch serialize, while anonymous variants and distinct server sources stay parallel. Client variants run fully parallel; server variants serialize only within their shared Steam source.